### PR TITLE
allow win on final guess

### DIFF
--- a/game/utils.go
+++ b/game/utils.go
@@ -165,7 +165,7 @@ func (m *AppModel) enter() tea.Cmd {
 		m.GameState = common.GameStateWon
 	}
 
-	if m.CurrentRow >= common.WordleMaxGuesses {
+	if m.CurrentRow >= common.WordleMaxGuesses && m.GameState != common.GameStateWon {
 		m.GameState = common.GameStateLost
 	}
 


### PR DESCRIPTION
This fixes a small bug where a correct guess on the final turn was counted as a loss.


![win-on-final-guess](https://user-images.githubusercontent.com/8356936/160726790-64f29072-8a95-49c2-89e0-b6cc62b23829.png)

