### PR TITLE
Use local timezone for word of day detection

### DIFF
--- a/words/words.go
+++ b/words/words.go
@@ -13,22 +13,22 @@ import (
 )
 
 func getWordOfTheDay(epoch time.Time) (string, int) {
-	now := time.Now().UTC()
+	now := time.Now()
 	year, month, day := now.Year(), now.Month(), now.Day()
 
-	currentDay := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	currentDay := time.Date(year, month, day, 0, 0, 0, 0, time.Local)
 
 	idx := int(math.Round(currentDay.Sub(epoch).Hours()/24)) % len(WordList)
 	return WordList[idx], idx
 }
 
 func GetOfficialWordOfTheDay() (string, int) {
-	wordleDay := time.Date(2021, time.Month(6), 19, 0, 0, 0, 0, time.UTC)
+	wordleDay := time.Date(2021, time.Month(6), 19, 0, 0, 0, 0, time.Local)
 	return getWordOfTheDay(wordleDay)
 }
 
 func GetWordOfTheDay() (string, int) {
-	wordleCliDay := time.Date(2001, time.Month(3), 7, 0, 0, 0, 0, time.UTC)
+	wordleCliDay := time.Date(2001, time.Month(3), 7, 0, 0, 0, 0, time.Local)
 	return getWordOfTheDay(wordleCliDay)
 }
 


### PR DESCRIPTION
I'm in central timezone.  At night (i.e. 11pm) I get a different word than the website because in UTC it is already the next day.